### PR TITLE
Add Trivy scan to REL_4_7

### DIFF
--- a/.github/workflows/trivy-scan.yaml
+++ b/.github/workflows/trivy-scan.yaml
@@ -6,9 +6,11 @@ on:
   pull_request:
     branches:
       - master
+      - REL_4_7
   push:
     branches:
       - master
+      - REL_4_7
   # Scan schedule is same as codeql-analysis job.
   schedule:
     - cron: '10 18 * * 2'


### PR DESCRIPTION
Scan for CVE's in Go dependencies.

Issue: [sc-17407]
